### PR TITLE
Solving final TODOs in RosettaPoseWrapper

### DIFF
--- a/src/menten_gcn/wrappers.py
+++ b/src/menten_gcn/wrappers.py
@@ -193,10 +193,10 @@ class RosettaPoseWrapper(WrappedPose):
         return xyz
 
     def resid_is_N_term(self, resid):
-        return self.pose.residue( resid ).is_lower_terminus()
+        return self.pose.residue(resid).is_lower_terminus()
 
     def resid_is_C_term(self, resid):
-        return self.pose.residue( resid ).is_upper_terminus()
+        return self.pose.residue(resid).is_upper_terminus()
 
     def resids_are_same_chain(self, resid1, resid2):
         return self.pose.chain(resid1) == self.pose.chain(resid2)

--- a/src/menten_gcn/wrappers.py
+++ b/src/menten_gcn/wrappers.py
@@ -193,12 +193,10 @@ class RosettaPoseWrapper(WrappedPose):
         return xyz
 
     def resid_is_N_term(self, resid):
-        # TODO
-        return False
+        return self.pose.residue( resid ).is_lower_terminus()
 
     def resid_is_C_term(self, resid):
-        # TODO
-        return False
+        return self.pose.residue( resid ).is_upper_terminus()
 
     def resids_are_same_chain(self, resid1, resid2):
         return self.pose.chain(resid1) == self.pose.chain(resid2)

--- a/tests/test_menten_gcn.py
+++ b/tests/test_menten_gcn.py
@@ -16,63 +16,6 @@ import mdtraj as md
 def test_main():
     pass
 
-def test_masks():
-    X_in = Input(shape=(3, 3), name='X_in')
-    A_in = Input(shape=(3, 3), name='A_in')
-    E_in = Input(shape=(3, 2), name='E_in')
-    X_mask = make_node_mask(A_in)
-    E_mask = make_edge_mask(A_in)
-    model = Model(inputs=[X_in,A_in,E_in], outputs=[X_mask,E_mask])
-    model.compile(optimizer='adam',
-                  loss='mean_squared_error' )
-    
-    testX = [[[ 0.,         -1.21597895,  1.94387676],
-              [ 1.,          2.01919905, -0.10534814],
-              [ 2.,          4.,          6.        ]]]
-    testA = [[[0., 1., 0.],
-              [1., 0., 0.],
-              [0., 0., 0.]]]
-    testE = [[[[1.,         2.        ],
-               [3.1,        4.1],
-               [5.,         6.        ],],
-
-              [[7.1,        8.1],
-               [9.,         1.        ],
-               [9.,         2.        ],],
-
-              [[8.,         3.        ],
-               [7.,         4.        ],
-               [6.,         5.        ],],]]
-
-    testX = np.asarray( testX ).astype('float32')
-    testA = np.asarray( testA ).astype('float32')
-    testE = np.asarray( testE ).astype('float32')
-
-    expectedX = [[[ 0.,         -1.21597895,  1.94387676],
-                  [ 1.,          2.01919905, -0.10534814],
-                  [ 0.,          0.,          0.        ]]]
-    expectedE = [[[[0.,         0.        ],
-                   [3.1,        4.1],
-                   [0.,         0.        ],],
-
-                  [[7.1,        8.1],
-                   [0.,         0.        ],
-                   [0.,         0.        ],],
-
-                  [[0.,         0.        ],
-                   [0.,         0.        ],
-                   [0.,         0.        ],],]]
-
-    expectedX = np.asarray( expectedX ).astype('float32')
-    expectedE = np.asarray( expectedE ).astype('float32')
-
-    
-    test_out = model.predict([testX,testA,testE])
-    equal = np.testing.assert_almost_equal
-    equal(np.asarray(expectedX), test_out[0], decimal=2)
-    equal(np.asarray(expectedE), test_out[1], decimal=2)
-    
-
 
 def NEE3_test_mask(Xval, Aval, Eval, N, F, S):
     # X_in = Input(shape=(N, F), name='X_in')

--- a/tests/test_menten_gcn.py
+++ b/tests/test_menten_gcn.py
@@ -16,6 +16,63 @@ import mdtraj as md
 def test_main():
     pass
 
+def test_masks():
+    X_in = Input(shape=(3, 3), name='X_in')
+    A_in = Input(shape=(3, 3), name='A_in')
+    E_in = Input(shape=(3, 2), name='E_in')
+    X_mask = make_node_mask(A_in)
+    E_mask = make_edge_mask(A_in)
+    model = Model(inputs=[X_in,A_in,E_in], outputs=[X_mask,E_mask])
+    model.compile(optimizer='adam',
+                  loss='mean_squared_error' )
+    
+    testX = [[[ 0.,         -1.21597895,  1.94387676],
+              [ 1.,          2.01919905, -0.10534814],
+              [ 2.,          4.,          6.        ]]]
+    testA = [[[0., 1., 0.],
+              [1., 0., 0.],
+              [0., 0., 0.]]]
+    testE = [[[[1.,         2.        ],
+               [3.1,        4.1],
+               [5.,         6.        ],],
+
+              [[7.1,        8.1],
+               [9.,         1.        ],
+               [9.,         2.        ],],
+
+              [[8.,         3.        ],
+               [7.,         4.        ],
+               [6.,         5.        ],],]]
+
+    testX = np.asarray( testX ).astype('float32')
+    testA = np.asarray( testA ).astype('float32')
+    testE = np.asarray( testE ).astype('float32')
+
+    expectedX = [[[ 0.,         -1.21597895,  1.94387676],
+                  [ 1.,          2.01919905, -0.10534814],
+                  [ 0.,          0.,          0.        ]]]
+    expectedE = [[[[0.,         0.        ],
+                   [3.1,        4.1],
+                   [0.,         0.        ],],
+
+                  [[7.1,        8.1],
+                   [0.,         0.        ],
+                   [0.,         0.        ],],
+
+                  [[0.,         0.        ],
+                   [0.,         0.        ],
+                   [0.,         0.        ],],]]
+
+    expectedX = np.asarray( expectedX ).astype('float32')
+    expectedE = np.asarray( expectedE ).astype('float32')
+
+    
+    test_out = model.predict([testX,testA,testE])
+    equal = np.testing.assert_almost_equal
+    equal(np.asarray(expectedX), test_out[0], decimal=2)
+    equal(np.asarray(expectedE), test_out[1], decimal=2)
+    
+
 
 def NEE3_test_mask(Xval, Aval, Eval, N, F, S):
     # X_in = Input(shape=(N, F), name='X_in')


### PR DESCRIPTION
It seems like termini handling still hasn't been solved. Well, here we go then

```py
from pyrosetta import *
import menten_gcn as mg
import menten_gcn.decorators as decs

pyrosetta.init()

d = decs.PhiPsiRadians(sincos=True)

pose = pose_from_sequence( "ASASAS" )
wpose = mg.RosettaPoseWrapper( pose )
for resid in range( 1, 7 ):
    print( d.calc_node_features( wpose, resid ), pose.residue( resid ).is_lower_terminus(), wpose.resid_is_N_term(resid), pose.residue( resid ).is_upper_terminus(), wpose.resid_is_C_term(resid) )
```

now gives

```
[ 0.0000000e+00  0.0000000e+00  1.2246468e-16 -1.0000000e+00] True True False False
[ 1.2246468e-16 -1.0000000e+00  1.2246468e-16 -1.0000000e+00] False False False False
[ 1.2246468e-16 -1.0000000e+00  1.2246468e-16 -1.0000000e+00] False False False False
[ 1.2246468e-16 -1.0000000e+00  1.2246468e-16 -1.0000000e+00] False False False False
[ 1.2246468e-16 -1.0000000e+00  1.2246468e-16 -1.0000000e+00] False False False False
[ 1.2246468e-16 -1.0000000e+00  0.0000000e+00  0.0000000e+00] False False True True
```